### PR TITLE
Feature/rag

### DIFF
--- a/rag/rag.go
+++ b/rag/rag.go
@@ -127,12 +127,17 @@ func (r *RAG) chunkDocuments(documents ...document.Document) []document.Document
 		}
 
 	}
-	print(len(newDocs))
 	return newDocs
 }
 
 func (r *RAG) AddDocuments(ctx context.Context, documents ...document.Document) error {
-	chunkedDocuments := r.chunkDocuments(documents...)
+	chunkedDocuments := textsplitter.NewRecursiveCharacterTextSplitter(
+		int(r.chunkSize),
+		int(r.chunkOverlap),
+	).SplitDocuments(documents)
+
+	//chunkedDocuments =r.chunkDocuments(documents...)
+
 	return r.index.LoadFromDocuments(ctx, chunkedDocuments)
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Added 1 method to split a document (containing content + metadata) based on the json structure of content. Also added the use of textsplitter on the RAG.AddDocument(), to split it based on the 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)