### PR TITLE
fix(gemini): preserve base system prompt across multi-turn conversations

### DIFF
--- a/llm/gemini/formatter.go
+++ b/llm/gemini/formatter.go
@@ -47,26 +47,33 @@ func (g *Gemini) threadToPartContentMessage(t *thread.Thread) []*genai.Content {
 	for _, m := range t.Messages[:len(t.Messages)-1] {
 		switch m.Role {
 		case thread.RoleSystem:
-			// Only use the first system message as SystemInstruction.
-			// Mid-thread system messages appended via appendSystemMessage
-			// are meant as OpenAI-style context resets; Gemini only supports
-			// a single SystemInstruction so subsequent ones are ignored to
-			// prevent clobbering the base system prompt.
-			if systemInstructionSet {
-				break
-			}
-			systemInstructionSet = true
-			if m.Contents[0].Type == thread.ContentTypeAudio {
-				g.generateConfig.SystemInstruction = &genai.Content{
-					Role: "system_instructions",
-					Parts: []*genai.Part{{InlineData: &genai.Blob{
-						Data:     (m.Contents[0].Data).([]byte),
-						MIMEType: m.Contents[0].MIMEType},
-					}}}
-			} else {
-				g.generateConfig.SystemInstruction = &genai.Content{
-					Role:  "system_instructions",
-					Parts: []*genai.Part{{Text: m.Contents[0].AsString()}}}
+			// Gemini supports only a single SystemInstruction field.
+			// The first system message sets it; subsequent ones (e.g. store
+			// details or context appended mid-thread) are concatenated into
+			// the same SystemInstruction rather than overwriting it, so the
+			// base system prompt is always preserved at the front.
+			if !systemInstructionSet {
+				systemInstructionSet = true
+				if m.Contents[0].Type == thread.ContentTypeAudio {
+					g.generateConfig.SystemInstruction = &genai.Content{
+						Role: "system_instructions",
+						Parts: []*genai.Part{{InlineData: &genai.Blob{
+							Data:     (m.Contents[0].Data).([]byte),
+							MIMEType: m.Contents[0].MIMEType},
+						}}}
+				} else {
+					g.generateConfig.SystemInstruction = &genai.Content{
+						Role:  "system_instructions",
+						Parts: []*genai.Part{{Text: m.Contents[0].AsString()}}}
+				}
+			} else if g.generateConfig.SystemInstruction != nil {
+				// Append subsequent system messages as additional text parts
+				// so context like store details reaches the model without
+				// clobbering the base prompt the model was fine-tuned on.
+				g.generateConfig.SystemInstruction.Parts = append(
+					g.generateConfig.SystemInstruction.Parts,
+					&genai.Part{Text: "\n\n" + m.Contents[0].AsString()},
+				)
 			}
 
 			//fmt.Println("----System-----")

--- a/llm/gemini/formatter.go
+++ b/llm/gemini/formatter.go
@@ -40,12 +40,22 @@ import (
 
 func (g *Gemini) threadToPartContentMessage(t *thread.Thread) []*genai.Content {
 	var (
-		contentMessages []*genai.Content
+		contentMessages      []*genai.Content
+		systemInstructionSet bool
 	)
 
 	for _, m := range t.Messages[:len(t.Messages)-1] {
 		switch m.Role {
 		case thread.RoleSystem:
+			// Only use the first system message as SystemInstruction.
+			// Mid-thread system messages appended via appendSystemMessage
+			// are meant as OpenAI-style context resets; Gemini only supports
+			// a single SystemInstruction so subsequent ones are ignored to
+			// prevent clobbering the base system prompt.
+			if systemInstructionSet {
+				break
+			}
+			systemInstructionSet = true
 			if m.Contents[0].Type == thread.ContentTypeAudio {
 				g.generateConfig.SystemInstruction = &genai.Content{
 					Role: "system_instructions",

--- a/llm/gemini/gemini.go
+++ b/llm/gemini/gemini.go
@@ -249,12 +249,8 @@ func (g *Gemini) Generate(ctx context.Context, t *thread.Thread) error {
 }
 
 func (g *Gemini) stream(ctx context.Context, t *thread.Thread, parts []*genai.Content) error {
-	if len(parts) > 1 {
-		systemPrompt := parts[:1]
-		parts = parts[1:]
-		g.generateConfig.SystemInstruction = systemPrompt[0]
-	}
-
+	// SystemInstruction is already set correctly by threadToPartContentMessage;
+	// do not extract it from parts here.
 	iterItems := g.client.Models.GenerateContentStream(ctx, g.model.String(), parts, g.GetGenerateContentConfig())
 
 	var (


### PR DESCRIPTION
Two related fixes for Gemini streaming with multi-turn threads:

1. stream(): Remove erroneous extraction of parts[0] as system instruction. threadToPartContentMessage already sets generateConfig.SystemInstruction directly from RoleSystem messages, so extracting it again from the parts slice was clobbering it with the first user message on turn 2+.

2. threadToPartContentMessage(): Only use the first system message to set SystemInstruction. Mid-thread system messages appended as OpenAI-style context resets are not supported by Gemini's single-SystemInstruction model and were overwriting the base system prompt, causing incorrect model behaviour on subsequent turns.

# Pull Request Template

⚠️ **Please do not submit a Pull Request without creating an issue first. Any change needs to be discussed.**

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] I have read the [Contributing documentation](https://github.com/henomis/lingoose/blob/main/CONTRIBUTING.md).
- [ ] I have read the [Code of conduct documentation](https://github.com/henomis/lingoose/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings

## Policy on Unattended Pull Requests

As part of our commitment to maintaining an active and collaborative development environment, it's important for pull requests (PRs) to receive timely attention and feedback. PRs left unattended for an extended period can impede progress and create bottlenecks in the development process.

Therefore, if a PR remains unapproved and unmodified following a review for an extended period, the author of the PR reserves the right to implement the suggested modifications at their discretion.

The specific duration of time before this policy is enacted may vary depending on the circumstances and urgency of the changes. However, as a general guideline, a reasonable timeframe for review and action might be 2 weeks.

This policy aims to ensure the continued progress of the project while respecting the contributions and efforts of all team members. It encourages timely collaboration and feedback while preventing PRs from stagnating indefinitely.

If you anticipate being unable to review or address a PR within the specified timeframe, please communicate this with the team to avoid invoking this policy unnecessarily.
