### PR TITLE
fix(gemini): guard against nil Content in stream iterator

### DIFF
--- a/llm/gemini/gemini.go
+++ b/llm/gemini/gemini.go
@@ -278,6 +278,9 @@ func (g *Gemini) stream(ctx context.Context, t *thread.Thread, parts []*genai.Co
 		}
 
 		//check func tool call
+		if response.Candidates[0].Content == nil || len(response.Candidates[0].Content.Parts) == 0 {
+			continue
+		}
 		part := response.Candidates[0].Content.Parts[0]
 		if part.FunctionCall != nil {
 			funCall := part.FunctionCall


### PR DESCRIPTION
Add nil check for Candidates[0].Content and Parts before accessing them in the stream loop. Gemini can return a candidate with nil Content on the final chunk when finish reason is SAFETY, RECITATION, or MAX_TOKENS — previously causing a nil pointer dereference panic.

UsageMetadata is already captured before the guard so token counting is unaffected. Brings stream path in line with the existing nil check in the generate path.